### PR TITLE
Fix openfeign timeout

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,13 @@ logging:
 spring:
   jackson:
     default-property-inclusion: NON_NULL
+  cloud:
+    openfeign:
+      client:
+        config:
+          openai-service:
+            connectTimeout: 160000
+            readTimeout: 160000
 
 management:
   endpoints:


### PR DESCRIPTION
 Due to openfeign's default timeout being very small, the openAI API does not always process responses to large questions in this amount of time.
 Increased client timeout to 2.6 minutes